### PR TITLE
add home_dir parameter to Telegram class constructor to specify custom telegram-cli home folder

### DIFF
--- a/pytg/__init__.py
+++ b/pytg/__init__.py
@@ -88,14 +88,15 @@ class Telegram(object):
             args.extend(custom_cli_args)
         logger.info("Starting Telegram Executable: \"{cmd}\"".format(cmd=" ".join(args)))
 
+        custom_env = None
         if self.home_dir:
             logger.info("Using custom Telegram home directory", self.home_dir)
             custom_env = os.environ.copy()
             custom_env["TELEGRAM_HOME"] = self.home_dir
-            self._proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                          preexec_fn=preexec_function, env=custom_env)
-        else:
-            self._proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, preexec_fn=preexec_function)
+        # end if
+        self._proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                      preexec_fn=preexec_function, env=custom_env)
+
         if self._check_stopped():
             raise AssertionError("CLI did stop, should be running...")
             # return pid


### PR DESCRIPTION
Allow pytg to run telegram-cli with different home folder (TELEGRAM_HOME env var). This allows to use more than one Telegram profile.