### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To upgrade append the ```--upgrade``` flag.
 
 ## **Usage**
 
->***Note***: The examples files produce syntax errors for python 3.0 - 3.2, the pytg package itself is not affacted by this!    
+>***Note***: The examples files produce syntax errors for python 3.0 - 3.2, the pytg package itself is not affected by this!    
 > To fix, just remove the ```u``` in front of the strings: change ```u"foobar"``` to ```"foobar``` (see [issue #39](https://github.com/luckydonald/pytg/issues/39#issuecomment-129992777) and [Python 3.3 accepts ```u'unicode'``` syntax again](https://docs.python.org/3/whatsnew/3.3.html?highlight=unicode)). 
 
 #### *Start* telegram
@@ -130,7 +130,7 @@ help(Sender)  # list all commands
 help(Sender.get_self)  # get help for a specific command
 ``` 
 
-This is also availabe as [generated documentation](https://github.com/luckydonald/pytg/blob/master/DOCUMENTATION.md) here on github.
+This is also available as [generated documentation](https://github.com/luckydonald/pytg/blob/master/DOCUMENTATION.md) here on github.
 Also have a look at the [Changelog](https://github.com/luckydonald/pytg/blob/master/CHANGELOG.md#changelog) to see what's going on.
 
 To generate the documentation yourself:
@@ -183,7 +183,7 @@ There are some example scripts in the [examples folder](https://github.com/lucky
     - This demonstrates how you could use `message_get` command and the `reply_id` information.
 
 - [bot_with_context](https://github.com/luckydonald/pytg/blob/master/examples/bot_with_context.py): Talk to a bot, not only a simple command.
-    - Demonstrates how to build converations with the use of generators and the `yield` statement.
+    - Demonstrates how to build conversations with the use of generators and the `yield` statement.
 
 
 ## URL Changes
@@ -198,7 +198,7 @@ git remote set-url origin https://github.com/luckydonald/pytg.git
 git pull
 # don't forget to install the newest official cli: https://github.com/vysheng/tg
 ```
-If that failes at some point, just Install it from scratch. 
+If that fails at some point, just Install it from scratch. 
 
 
 Thanks!

--- a/examples/bot_ping.py
+++ b/examples/bot_ping.py
@@ -57,8 +57,8 @@ def example_function(sender):  # name "example_function" and given parameters ar
             if msg.text is None:  # we have media instead.
                 continue  # and again, because we want to process only text message.
             # Everything in pytg will be unicode. If you use python 3 thats no problem,
-            # just if you use python 2 you have to be carefull! (better switch to 3)
-            # for convinience of py2 users there is a to_unicode(<string>) in pytg.encoding
+            # just if you use python 2 you have to be careful! (better switch to 3)
+            # for convenience of py2 users there is a to_unicode(<string>) in pytg.encoding
             # for python 3 the using of it is not needed.
             # But again, use python 3, as you have a chat with umlaute and emojis.
             # This WILL brake your python 2 code at some point!
@@ -79,7 +79,7 @@ def example_function(sender):  # name "example_function" and given parameters ar
         # we got a KeyboardIterrupt(Ctrl+C)
         pass
     else:
-        # the loop exited without exception, becaues _quit was set True
+        # the loop exited without exception, because _quit was set True
         pass
 
 

--- a/examples/bot_source_of_reply.py
+++ b/examples/bot_source_of_reply.py
@@ -69,8 +69,8 @@ def message_loop(sender):  # name "message_loop" and given parameters are define
             if msg.text is None:  # we have media instead.
                 continue  # and again, because we want to process only text message.
                 # Everything in pytg will be unicode. If you use python 3 thats no problem,
-                # just if you use python 2 you have to be carefull! (better switch to 3)
-                # for convinience of py2 users there is a to_unicode(<string>) in pytg.encoding
+                # just if you use python 2 you have to be careful! (better switch to 3)
+                # for convenience of py2 users there is a to_unicode(<string>) in pytg.encoding
                 # for python 3 the using of it is not needed.
                 # But again, use python 3, as you have a chat with umlaute and emojis.
                 # This WILL brake your python 2 code at some point!
@@ -87,7 +87,7 @@ def message_loop(sender):  # name "message_loop" and given parameters are define
         # we got a KeyboardIterrupt(Ctrl+C)
         pass
     else:
-        # the loop exited without exception, becaues _quit was set True
+        # the loop exited without exception, because _quit was set True
         pass
 
 

--- a/examples/bot_with_context.py
+++ b/examples/bot_with_context.py
@@ -102,7 +102,7 @@ def message_loop(sender):  # name "message_loop" and given parameters are define
         # we got a KeyboardIterrupt(Ctrl+C)
         pass
     else:
-        # the loop exited without exception, becaues _quit was set True
+        # the loop exited without exception, because _quit was set True
         pass
 
 
@@ -127,8 +127,8 @@ def should_skip_message(msg, sender, only_allow_user=None):
     if "text" not in msg or msg.text is None:  # we have media instead.
         return True  # and again, because we want to process only text message.
         # Everything in pytg will be unicode. If you use python 3 thats no problem,
-        # just if you use python 2 you have to be carefull! (better switch to 3)
-        # for convinience of py2 users there is a to_unicode(<string>) in pytg.encoding
+        # just if you use python 2 you have to be careful! (better switch to 3)
+        # for convenience of py2 users there is a to_unicode(<string>) in pytg.encoding
         # for python 3 the using of it is not needed.
         # But again, use python 3, as you have a chat with umlaute and emojis.
         # This WILL brake your python 2 code at some point!

--- a/pytg/__init__.py
+++ b/pytg/__init__.py
@@ -22,7 +22,7 @@ __version__ = VERSION  # PEP-0396
 class Telegram(object):
     """
     To have the sender and the receiver in one handsome object.
-    Also is able to start the CLI, and stop it respectivly.
+    Also is able to start the CLI, and stop it respectively.
     """
 
     def __init__(self, host="127.0.0.1", port=4458, telegram=None, pubkey_file=None, custom_cli_args=None,

--- a/pytg/exceptions.py
+++ b/pytg/exceptions.py
@@ -28,7 +28,7 @@ class IllegalResponseException(Exception):
 # result_parser.py/sender.py
 class FailException(IllegalResponseException):
     """
-    Used when the cli sends somethhing like
+    Used when the cli sends something like
     {'error_code': 100, 'result': 'FAIL', 'error': 'RPC_CALL_FAIL 400: USERNAME_INVALID'}
 
     This class has the following attributes:
@@ -38,7 +38,7 @@ class FailException(IllegalResponseException):
 
     def __init__(self, error_code, error, command=None):
         """
-        :param error_code: The error code returnded by the CLI.
+        :param error_code: The error code returned by the CLI.
         :type  error_code: int
         :param error: The message the CLI gives us.
         :type  error: str

--- a/pytg/fix_msg_array.py
+++ b/pytg/fix_msg_array.py
@@ -64,7 +64,7 @@ def fix_peer(peer):
     # remove print_name field
     # create name field
     if "print_name" in peer:
-        peer["name"] = peer["print_name"]  # just in case everything failes.
+        peer["name"] = peer["print_name"]  # just in case everything fails.
         del peer["print_name"]
         # can contain ugly print_names like "user#123", "chat#123" or "no_spaces_just_underscores"
     else:

--- a/pytg/sender.py
+++ b/pytg/sender.py
@@ -51,7 +51,7 @@ functions["send_video"]           = ("send_video", [args.Peer("peer"), args.File
 functions["send_document"]        = ("send_document", [args.Peer("peer"), args.FilePath("file"), args.UnicodeString("caption", optional=True)], res.success_fail, 120.0, "Sends document to peer (as raw file including filename)")
 functions["send_file"]            = ("send_file", [args.Peer("peer"), args.FilePath("file")], res.success_fail, 120.0, "Sends document to peer (using the best available method, e.g. songs as audio and images as photos)")
 functions["send_location"]        = ("send_location", [args.Peer("peer"), args.Double("latitude"), args.Double("longitude")], res.success_fail, None, "Sends geo location")
-functions["send_contact"]         = ("send_contact", [args.Peer("peer"), args.UnicodeString("phone"), args.UnicodeString("first_name"), args.UnicodeString("last_name")], res.something, 60.0, "Sends contact (not necessary telegram user).")  # what did the "ret: formated message" help string mean?
+functions["send_contact"]         = ("send_contact", [args.Peer("peer"), args.UnicodeString("phone"), args.UnicodeString("first_name"), args.UnicodeString("last_name")], res.something, 60.0, "Sends contact (not necessary telegram user).")  # what did the "ret: formatted message" help string mean?
 functions["send_text_from_file"]  = ("send_text", [args.Peer("peer"), args.FilePath("file")], res.success_fail, 60.0, "Sends contents of text file as plain text message")
 functions["fwd"]                  = ("fwd", [args.Peer("peer"), args.MsgId("msg_id")], res.success_fail, None, "Forwards message to peer. Forward to secret chats is forbidden")
 functions["fwd_media"]            = ("fwd_media", [args.Peer("peer"), args.MsgId("msg_id")], res.success_fail, None, "Forwards message media to peer. Forward to secret chats is forbidden. Result slightly differs from fwd")
@@ -187,7 +187,7 @@ reply_functions["send_contact"]         = "reply_contact"
 # //    functions["secret_chat_rekey"] = ("secret_chat_rekey", [args.SecretChat("secret_chat")], res.success_fail, None, "generate new key for active secret chat"
 # "set": ("set", [ca_string, ca_number, ca_none,"<param> <value>"], res.success_fail, None),  # Sets value of param. Currently available: log_level, debug_verbosity, alarm, msg_num
 
-# These are not concidered useful, so I implement other things first. If needed, create an issue, or send an pull-request.
+# These are not considered useful, so I implement other things first. If needed, create an issue, or send an pull-request.
 
 #     functions["show_license"] = ("show_license", [ca_none,""], res.success_fail, None, "Prints contents of GPL license"
 #     functions["stats"] = ("stats", [ca_none,""], res.success_fail, None, "For debug purpose"
@@ -361,7 +361,7 @@ class Sender(object):
     def _validate_input(function_name, arguments):
         """
         This will check if the arguments fit the functions needed parameters.
-        Returns a tuple of cli command name and the arguments formated as unicode strings.
+        Returns a tuple of cli command name and the arguments formatted as unicode strings.
 
         :param function_name: The name of the called function.
         :type function_name: str
@@ -586,7 +586,7 @@ class Sender(object):
             if self.s:
                 # self.s.settimeout(0)
                 self.s.close()  # not let the cli end close first -> avoid bind: port already in use.
-            return  # don't abort sending, let it do stuff, it will suceed or fail soon anyway.
+            return  # don't abort sending, let it do stuff, it will succeed or fail soon anyway.
             #       # Well, hopefully. Else something like this should work:
             # if self.s:
             #     self.s.close()


### PR DESCRIPTION
There are small typos in:
- README.md
- examples/bot_ping.py
- examples/bot_source_of_reply.py
- examples/bot_with_context.py
- pytg/__init__.py
- pytg/exceptions.py
- pytg/fix_msg_array.py
- pytg/sender.py

Fixes:
- Should read `convenience` rather than `convinience`.
- Should read `careful` rather than `carefull`.
- Should read `because` rather than `becaues`.
- Should read `formatted` rather than `formated`.
- Should read `fails` rather than `failes`.
- Should read `succeed` rather than `suceed`.
- Should read `something` rather than `somethhing`.
- Should read `returned` rather than `returnded`.
- Should read `respectively` rather than `respectivly`.
- Should read `conversations` rather than `converations`.
- Should read `considered` rather than `concidered`.
- Should read `available` rather than `availabe`.
- Should read `affected` rather than `affacted`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md